### PR TITLE
fix: fetch changelogs from private terraform registries

### DIFF
--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -10,7 +10,7 @@ require "dependabot/terraform/version"
 module Dependabot
   module Terraform
     # Terraform::RegistryClient is a basic API client to interact with a
-    # terraform registry: https://www.terraform.io/docs/registry/api.html
+    # terraform registry: https://developer.hashicorp.com/terraform/registry/api-docs
     class RegistryClient
       extend T::Sig
 
@@ -114,26 +114,11 @@ module Dependabot
       sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::Source)) }
       def source(dependency:)
         type = T.must(dependency.requirements.first)[:source][:type]
-        base_url = service_url_for(service_key_for(type))
-        case type
-        # https://www.terraform.io/internals/module-registry-protocol#download-source-code-for-a-specific-module-version
-        when "module", "modules", "registry"
-          download_url = URI.join(base_url, "#{dependency.name}/#{dependency.version}/download")
-          response = http_get(download_url)
-          return nil unless response.status == 204
+        source_url = fetch_source_url(dependency, type)
 
-          source_url = response.headers.fetch("X-Terraform-Get")
-          source_url = URI.join(download_url, source_url) if
-            source_url.start_with?("/", "./", "../")
-          source_url = RegistryClient.get_proxied_source(source_url) if source_url
-        when "provider", "providers"
-          response = http_get(URI.join(base_url, "#{dependency.name}/#{dependency.version}"))
-          return nil unless response.status == 200
+        return nil unless source_url
 
-          source_url = JSON.parse(response.body).fetch("source")
-        end
-
-        Source.from_url(source_url) if source_url
+        parse_source_url(source_url, dependency, type)
       rescue JSON::ParserError, Excon::Error::Timeout
         nil
       end
@@ -153,6 +138,120 @@ module Dependabot
       end
 
       private
+
+      # Fetch source URL from registry API. The source can be a module or a
+      # provider, both using different endpoints and response formats.
+      #
+      # @param dependency [Dependabot::Dependency] the dependency to fetch the
+      # source for
+      # @param type [String] the type of the dependency, normally either
+      # "module" or "provider"
+      # @return [String, nil] the source URL or nil if not found
+      sig { params(dependency: Dependabot::Dependency, type: String).returns(T.nilable(String)) }
+      def fetch_source_url(dependency, type)
+        base_url = service_url_for(service_key_for(type))
+        case type
+        when "module", "modules", "registry"
+          fetch_module_source_url(dependency, base_url)
+        when "provider", "providers"
+          fetch_provider_source_url(dependency, base_url)
+        end
+      end
+
+      # Fetch the source URL of a given module dependency.
+      #
+      # See:
+      # - https://www.terraform.io/internals/module-registry-protocol#download-source-code-for-a-specific-module-version
+      #
+      # @param dependency [Dependabot::Dependency] the module dependency
+      # @param base_url [String] the base URL for the module registry service
+      # @return [String, nil] the source URL or nil if not found
+      sig { params(dependency: Dependabot::Dependency, base_url: String).returns(T.nilable(String)) }
+      def fetch_module_source_url(dependency, base_url)
+        # Example: https://registry.terraform.io/v1/modules/hashicorp/consul/aws/0.3.8/download
+        download_url = URI.join(base_url, "#{dependency.name}/#{dependency.version}/download")
+        response = http_get(download_url)
+        return nil unless response.status == 204
+
+        source_url = response.headers["X-Terraform-Get"]
+        return nil unless source_url
+
+        source_url = URI.join(download_url, source_url) if
+          source_url.start_with?("/", "./", "../")
+        RegistryClient.get_proxied_source(source_url.to_s) if source_url
+      end
+
+      # Fetch the source URL of a given provider dependency.
+      #
+      # See:
+      # - https://developer.hashicorp.com/terraform/internals/provider-registry-protocol#find-a-provider-package
+      #
+      # @param dependency [Dependabot::Dependency] the provider dependency
+      # @param base_url [String] the base URL for the provider registry service
+      # @return [String, nil] the source URL or nil if not found
+      sig { params(dependency: Dependabot::Dependency, base_url: String).returns(T.nilable(String)) }
+      def fetch_provider_source_url(dependency, base_url)
+        # Example: https://registry.terraform.io/v1/providers/hashicorp/aws/3.40.0
+        response = http_get(URI.join(base_url, "#{dependency.name}/#{dependency.version}"))
+        return nil unless response.status == 200
+
+        JSON.parse(response.body).fetch("source")
+      end
+
+      # Parse source URL into Dependabot::Source object with fallback for archivist URLs.
+      # When download endpoints return unparseable archivist URLs (encrypted blob storage),
+      # falls back to the module metadata API to get the actual repository URL.
+      #
+      # See:
+      # - https://developer.hashicorp.com/terraform/internals/module-registry-protocol#download-source-code-for-a-specific-module-version
+      # - https://developer.hashicorp.com/terraform/cloud-docs/architectural-details/security-model (archivist URLs)
+      #
+      # @param source_url [String] the source URL to parse (may be archivist URL)
+      # @param dependency [Dependabot::Dependency] the dependency for fallback metadata lookup
+      # @param type [String] the type of the dependency ("module", "provider", "registry")
+      # @return [Dependabot::Source, nil] the parsed source or nil if not found
+      sig do
+        params(
+          source_url: String,
+          dependency: Dependabot::Dependency,
+          type: String
+        ).returns(T.nilable(Dependabot::Source))
+      end
+      def parse_source_url(source_url, dependency, type)
+        result = Source.from_url(source_url)
+
+        # If Source.from_url fails (e.g., with archivist URLs), try to get source from module metadata
+        result = source_from_module_metadata(dependency) if result.nil? && type == "registry"
+
+        result
+      end
+
+      # Fallback to fetch source repository URL from module metadata API.
+      # Used when X-Terraform-Get header returns unparseable archivist URLs like:
+      # https://archivist.terraform.io/v1/object/dmF1bHQ6djE6... (encrypted blob storage)
+      #
+      # The metadata API returns JSON with the actual repository URL in the "source" field.
+      #
+      # See: https://developer.hashicorp.com/terraform/registry/api-docs#show-a-module
+      #
+      # @param dependency [Dependabot::Dependency] the dependency to fetch metadata for
+      # @return [Dependabot::Source, nil] the parsed source or nil if not found
+      sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::Source)) }
+      def source_from_module_metadata(dependency)
+        base_url = service_url_for("modules.v1")
+        metadata_url = URI.join(base_url, dependency.name.to_s)
+
+        response = http_get(metadata_url)
+        return nil unless response.status == 200
+
+        data = JSON.parse(response.body)
+        source_url = data["source"]
+
+        Source.from_url(source_url) if source_url
+      rescue JSON::ParserError, Excon::Error => e
+        Dependabot.logger.warn("Failed to fetch module metadata for #{dependency.name}: #{e.message}")
+        nil
+      end
 
       sig { returns(String) }
       attr_reader :hostname


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to make dependabot fetch changelogs for modules stored in private registries. This was failing before because these registries return URLs for blob-encoded files with no metadata. In those cases, the [metadata endpoints need to be used](https://developer.hashicorp.com/terraform/registry/api-docs#download-source-code-for-a-specific-module-version)

Fixes #7010

### Anything you want to highlight for special attention from reviewers?

First PR for dependabot, so I'm not quite sure on what I did right / wrong here. I had to refactor a function to avoid rubocop from coplaining about complexity (and I assumed that silencing it wouldn't be ok without your geenlight). Feel free to let me know if you prefer me to handle it differently.

### How will you know you've accomplished your goal?

This is hard to test, as it relies on private registries and API keys, but I'm happy to do whatever you need me to so that you are assured that it works as you'd expect it to. Setting up a private environment might be tricky and credentials sharing might be required, if we choose to pursue that.

Personally, I've run this with the `bin/dry-run.rb` script with a set of credentials and it worked as expected. You can find an example run below where I've redacted some bits that contain some information I'd prefer not to share. 

Note that at the time of writing this issue there's an upstream problem with `bin/dry-run.rb` (see https://github.com/dependabot/dependabot-core/issues/12889).

<details>
<summary>Click to expand sample run</summary>

```
[dependabot-core-dev] ~ $ ruby bin/dry-run.rb terraform redacted-org/redacted-repo --dir="/terraform/redacted-dir" --cache=files --pull-request
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading cloned repo from /home/dependabot/tmp/redacted-org/redacted-repo
=> parsing dependency files
=> updating 3 dependencies: hashicorp/aws, redacted-org/redacted-module-name/aws, tailscale/tailscale

=== hashicorp/aws ()
 => checking for updates 1/3
🌍 --> GET https://registry.terraform.io/.well-known/terraform.json
🌍 <-- 200 https://registry.terraform.io/.well-known/terraform.json
🌍 --> GET https://registry.terraform.io/v1/providers/hashicorp/aws/versions
🌍 <-- 200 https://registry.terraform.io/v1/providers/hashicorp/aws/versions
 => latest available version is 6.9.0
    (no update needed as it's already up-to-date)

=== redacted-org/redacted-module-name/aws (0.51.0)
 => checking for updates 2/3
🌍 --> GET https://app.terraform.io/.well-known/terraform.json
🌍 <-- 200 https://app.terraform.io/.well-known/terraform.json
🌍 --> GET https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws/versions
🌍 <-- 200 https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws/versions
 => latest available version is 0.51.1
 => latest allowed version is 0.51.1
 => requirements to unlock: own
 => requirements update strategy: 
🌍 --> GET https://app.terraform.io/.well-known/terraform.json
🌍 <-- 200 https://app.terraform.io/.well-known/terraform.json
🌍 --> GET https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws/0.51.1/download
🌍 <-- 204 https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws/0.51.1/download
🌍 --> GET https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws
🌍 <-- 200 https://app.terraform.io/api/registry/v1/modules/redacted-org/redacted-module-name/aws
🌍 --> GET https://github.com/redacted-org/terraform-aws-redacted-module-name.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/redacted-org/terraform-aws-redacted-module-name.git/info/refs?service=git-upload-pack
🌍 --> GET https://github.com/redacted-org/terraform-aws-redacted-module-name.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/redacted-org/terraform-aws-redacted-module-name.git/info/refs?service=git-upload-pack
 => bump redacted-org/redacted-module-name/aws from 0.51.0 to 0.51.1 in /terraform/redacted-dir

    ± terraform/redacted-dir/main.tf
    ~~~
    --- /tmp/original20250820-36-dlxumi	2025-08-20 11:40:47.296379636 +0000
    +++ /tmp/updated20250820-36-x4vfc8	2025-08-20 11:40:47.296818846 +0000
    @@ -1,6 +1,6 @@
     module "infra_stack" {
       source  = "app.terraform.io/redacted-org/redacted-module-name/aws"
    -  version = "0.51.0"
    +  version = "0.51.1"
     
    ~~~
    2 insertions (+), 2 deletions (-)
Pull Request Title: Bump redacted-org/redacted-module-name/aws from 0.51.0 to 0.51.1 in /terraform/redacted-dir
--description--
Bumps [redacted-org/redacted-module-name/aws](https://github.com/redacted-org/terraform-aws-redacted-module-name) from 0.51.0 to 0.51.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/redacted-org/terraform-aws-redacted-module-name/releases">redacted-org/redacted-module-name/aws's releases</a>.</em></p>
<blockquote>
<h2>v0.51.1</h2>
<p>Version 0.51.1</p>
<h2>What's Changed</h2>
<ul>
<li>update(tf): bump redacted-org/redacted-module-number-2/aws from 1.0.0 to 1.1.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/redacted-org/terraform-aws-redacted-module-name/pull/386">redacted-org/terraform-aws-redacted-module-name#386</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/redacted-org/terraform-aws-redacted-module-name/compare/v0.51.0...v0.51.1">https://github.com/redacted-org/terraform-aws-redacted-module-name/compare/v0.51.0...v0.51.1</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/redacted-org/terraform-aws-redacted-module-name/commit/d8688440e77d871c14f42736cae3769af90c8d7a"><code>d868844</code></a> update(tf): bump redacted-org/redacted-module-number-2/aws from 1.0.0 to 1.1.0</li>
<li>See full diff in <a href="https://github.com/redacted-org/terraform-aws-redacted-module-name/compare/v0.51.0...v0.51.1">compare view</a></li>
</ul>
</details>
<br />

--/description--
--commit--
Bump redacted-org/redacted-module-name/aws in /terraform/redacted-dir

Bumps [redacted-org/redacted-module-name/aws](https://github.com/redacted-org/terraform-aws-redacted-module-name) from 0.51.0 to 0.51.1.
- [Release notes](https://github.com/redacted-org/terraform-aws-redacted-module-name/releases)
- [Commits](https://github.com/redacted-org/terraform-aws-redacted-module-name/compare/v0.51.0...v0.51.1)
--/commit--

=== tailscale/tailscale ()
 => checking for updates 3/3
🌍 --> GET https://registry.terraform.io/.well-known/terraform.json
🌍 <-- 200 https://registry.terraform.io/.well-known/terraform.json
🌍 --> GET https://registry.terraform.io/v1/providers/tailscale/tailscale/versions
🌍 <-- 200 https://registry.terraform.io/v1/providers/tailscale/tailscale/versions
 => latest available version is 0.21.1
    (no update needed as it's already up-to-date)
🌍 Total requests made: '11'
Dry-run completed successfully.

```
</details>

In the sample above, we can see how dependabot shows a PR description for a changelog that contains `bump redacted-org/redacted-module-number-2/aws`, which is a module in a private registry. Until now, dependabot simply showed up an empty changelog, as shown below:

<img width="2740" height="1080" alt="imagen" src="https://github.com/user-attachments/assets/76c7b4b0-ebb8-4184-8c9b-0cb710a14862" />



<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
